### PR TITLE
Anpassbare Knast Online Zeit

### DIFF
--- a/nrp.sql
+++ b/nrp.sql
@@ -1528,7 +1528,7 @@ CREATE TABLE `einstellungen` (
   `players` int(3) DEFAULT 0,
   `binfernus` int(2) DEFAULT NULL,
   `eleklic` int(6) DEFAULT 55000,
-  `mdcpw` varchar(20) DEFAULT 'n/A',
+  `KnastOnline` int(10) DEFAULT 0,
   `mdcpw1` varchar(20) DEFAULT 'n/A'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 


### PR DESCRIPTION
Ab dem Rang Manager ist es nun möglich via /setknastonline den Prozentsatz festzulegen, welcher entscheidet wie viel der Knast Zeit Online verbracht werden muss. Ebenfalls ist es möglich diese gänzlich abzuschalten.

Damit die DB nicht unnötig vollgemüllt wird haben wir den Datenbankeintrag des mdcpw überschrieben zu KnastOnline.